### PR TITLE
Fix runtime errors from project refactor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         "numpy",
         "matplotlib",
         "pycbc",
+        "scikit-learn>=1.0",
         "p_astro @ git+https://git.ligo.org/lscsoft/p-astro.git@master#egg=p_astro",
     ],
     description="A Python library for SPIIR gravitational wave search algorithms.",

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ setup(
     install_requires=[
         "numpy",
         "matplotlib",
-        "pycbc",
         "scikit-learn>=1.0",
+        "pycbc @ git+https://github.com/gwastro/pycbc.git@master#egg=pycbc",
         "p_astro @ git+https://git.ligo.org/lscsoft/p-astro.git@master#egg=p_astro",
     ],
     description="A Python library for SPIIR gravitational wave search algorithms.",

--- a/src/spiir/search/p_astro/__init__.py
+++ b/src/spiir/search/p_astro/__init__.py
@@ -1,5 +1,3 @@
-from ligo.p_astro import get_f_over_b
-
 from . import mchirp_area, models
 from .mchirp_area import ChirpMassAreaModel
 from .models import CompositeModel, TwoComponentModel

--- a/src/spiir/search/p_astro/__init__.py
+++ b/src/spiir/search/p_astro/__init__.py
@@ -1,3 +1,5 @@
+from ligo.p_astro import get_f_over_b
+
 from . import mchirp_area, models
 from .mchirp_area import ChirpMassAreaModel
 from .models import CompositeModel, TwoComponentModel

--- a/src/spiir/search/p_astro/mchirp_area.py
+++ b/src/spiir/search/p_astro/mchirp_area.py
@@ -51,7 +51,6 @@ class ChirpMassAreaModel:
         mass_gap_max: Optional[float] = None,
         separate_mass_gap: bool = False,
         lal_cosmology: bool = True,
-        distance_lower_bound: float = 1e-4,
     ):
         """Defines a Compact Binary Coalescence source classifier class based on the
         PyCBC Chirp Mass Area method (mchirp_area.py) by Villa-Ortega et. al. (2021).
@@ -78,9 +77,6 @@ class ChirpMassAreaModel:
         lal_cosmology: bool
             If True, it uses the Planck15 cosmology model as defined in
              lalsuite instead of the astropy default.
-        distance_lower_bound: float
-            If provided, the ceiling of the distance_lower_bound and the estimated
-            lower uncertainty bound will be selected for distance estimation.
         """
         # model coefficients
         self.a0, self.b0, self.b1, self.m0 = a0, b0, b1, m0
@@ -93,7 +89,6 @@ class ChirpMassAreaModel:
         assert 0 < ns_max <= (self.mass_gap_max or ns_max)
 
         self.lal_cosmology = lal_cosmology
-        # self.distance_lower_bound = distance_lower_bound  # not supported by pycbc
 
     def __repr__(self, precision: int = 4):
         """Overrides string representation of cls when printed."""

--- a/src/spiir/search/p_astro/mchirp_area.py
+++ b/src/spiir/search/p_astro/mchirp_area.py
@@ -404,7 +404,7 @@ def draw_mass_contour_plane(
         /blob/f2656b4762a232d4758db88569e0b7ab45756ead/mc_area_plots.py
     """
     # determine component masses (when m1 = m2) given chirp mass boundaries
-    mcb, mcs = mchirp_lower, mchirp_upper
+    mcs, mcb = mchirp_lower, mchirp_upper
     mib = (2.0**0.2) * mcb
     mis = (2.0**0.2) * mcs
 

--- a/src/spiir/search/p_astro/mchirp_area.py
+++ b/src/spiir/search/p_astro/mchirp_area.py
@@ -334,29 +334,27 @@ class ChirpMassAreaModel:
 
     def save(self, path: Union[str, Path]):
         file_path = Path(path)
-        match file_path.suffix:
-            case ".pkl":
-                self.save_pkl(file_path)
-            case ".json":
-                self.save_json(file_path)
-            case _:
-                raise RuntimeError(
-                    f"Save failed - cannot detect file type: {file_path.suffix}. "
-                    "Valid file types are '.pkl' or '.json'."
-                )
+        if file_path.suffix == ".pkl":
+            self.save_pkl(file_path)
+        elif file_path.suffix == ".json":
+            self.load_json(file_path)
+        else:
+            raise RuntimeError(
+                f"Save failed - cannot detect file type: {file_path.suffix}. "
+                "Valid file types are '.pkl' or '.json'."
+            )
 
     def load(self, path: Union[str, Path]):
         file_path = Path(path)
-        match file_path.suffix:
-            case ".pkl":
-                self.load_pkl(file_path)
-            case ".json":
-                self.load_json(file_path)
-            case _:
-                raise RuntimeError(
-                    f"Save failed - cannot detect file type: {file_path.suffix}. "
-                    "Valid file types are '.pkl' or '.json'."
-                )
+        if file_path.suffix == ".pkl":
+            self.load_pkl(file_path)
+        elif file_path.suffix == ".json":
+            self.load_json(file_path)
+        else:
+            raise RuntimeError(
+                f"Save failed - cannot detect file type: {file_path.suffix}. "
+                "Valid file types are '.pkl' or '.json'."
+            )
 
     def save_pkl(self, path: Union[str, Path]):
         with Path(path).open(mode="wb") as f:

--- a/src/spiir/search/p_astro/models.py
+++ b/src/spiir/search/p_astro/models.py
@@ -117,11 +117,11 @@ class TwoComponentModel:
 class CompositeModel:
     def __init__(
         self,
-        signal_model: TwoComponentModel,
-        source_model: ChirpMassAreaModel,
+        signal_model: Optional[TwoComponentModel] = None,
+        source_model: Optional[ChirpMassAreaModel] = None,
     ):
-        self.signal_model = signal_model
-        self.source_model = source_model
+        self.signal_model = signal_model or TwoComponentModel()
+        self.source_model = source_model or ChirpMassAreaModel()
 
     def load(
         self,

--- a/src/spiir/search/p_astro/models.py
+++ b/src/spiir/search/p_astro/models.py
@@ -35,6 +35,7 @@ class TwoComponentModel:
         self.prior_type = prior_type
 
         # mean posterior counts
+        self.marginalized_posterior: Optional[MarginalizedPosterior] = None
         self.mean_counts: Optional[Dict[str, float]] = None
 
     def __repr__(self, precision: int = 4):
@@ -74,6 +75,7 @@ class TwoComponentModel:
         return self
 
     def predict(self, far: float, snr: float) -> float:
+        assert self.marginalized_posterior is not None, f"Model not fit - call .fit()."
         bayes_factors = get_f_over_b(far, snr, self.far_threshold, self.snr_threshold)
         return self.marginalized_posterior.pastro_update(
             categories=["Astro"],

--- a/src/spiir/search/p_astro/models.py
+++ b/src/spiir/search/p_astro/models.py
@@ -83,29 +83,27 @@ class TwoComponentModel:
 
     def save(self, path: Union[str, Path]):
         file_path = Path(path)
-        match file_path.suffix:
-            case ".pkl":
-                self.save_pkl(file_path)
-            case ".json":
-                raise NotImplementedError("JSON compatibility not yet implemented.")
-            case _:
-                raise RuntimeError(
-                    f"Save failed - cannot detect file type: {file_path.suffix}. "
-                    "Valid file types are '.pkl'."
-                )
+        if file_path.suffix == ".pkl":
+            self.save_pkl(file_path)
+        elif file_path.suffix == ".json":
+            raise NotImplementedError("JSON compatibility not yet implemented.")
+        else:
+            raise RuntimeError(
+                f"Save failed - cannot detect file type: {file_path.suffix}. "
+                "Valid file types are '.pkl'."
+            )
 
     def load(self, path: Union[str, Path]):
         file_path = Path(path)
-        match file_path.suffix:
-            case ".pkl":
-                self.load_pkl(file_path)
-            case ".json":
-                raise NotImplementedError("JSON compatibility not yet implemented.")
-            case _:
-                raise RuntimeError(
-                    f"Save failed - cannot detect file type: {file_path.suffix}. "
-                    "Valid file types are '.pkl'."
-                )
+        if file_path.suffix == ".pkl":
+            self.load_pkl(file_path)
+        elif file_path.suffix == ".json":
+            raise NotImplementedError("JSON compatibility not yet implemented.")
+        else:
+            raise RuntimeError(
+                f"Save failed - cannot detect file type: {file_path.suffix}. "
+                "Valid file types are '.pkl'."
+            )
 
     def save_pkl(self, path: Union[str, Path]):
         with Path(path).open(mode="wb") as f:

--- a/src/spiir/search/p_astro/models.py
+++ b/src/spiir/search/p_astro/models.py
@@ -75,7 +75,7 @@ class TwoComponentModel:
         return self
 
     def predict(self, far: float, snr: float) -> float:
-        assert self.marginalized_posterior is not None, f"Model not fit - call .fit()."
+        assert self.marginalized_posterior is not None, "Model not fit - call .fit()."
         bayes_factors = get_f_over_b(far, snr, self.far_threshold, self.snr_threshold)
         return self.marginalized_posterior.pastro_update(
             categories=["Astro"],


### PR DESCRIPTION
This merge request fixes a flew problems remaining from the project refactor from `spiir` to the `spiir.search` namespace package.

Other than code logic fixes, we have implemented:
- A suppressed warning for astropy.cosmology z_at_value for when luminosity distances are negative.
- A bug in the `draw_mass_contour_plot` function where the lower and upper luminosity distance bounds were swapped.
- An update to setup.py which updates scikit-learn.
- An update to setup.py which updates pycbc from v2.0.3 installed with igwn-py38 to the master branch at pycbc's github repository, which include changes to the mchirp_area module which better handle mass gap classifications.
    - This version of the mchirp_area module is not available on conda-forge and must be manually updated, replacing the original pycbc installation. 